### PR TITLE
Removed billing/shipping state children from xml

### DIFF
--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -99,7 +99,6 @@ class AuthorizeRequest extends AbstractRequest
             $billingDetails->addChild('street', $card->getBillingAddress1());
             $billingDetails->addChild('street2', $card->getBillingAddress2());
             $billingDetails->addChild('city', $card->getBillingCity());
-            $billingDetails->addChild('state', $card->getBillingState());
             $billingDetails->addChild('country', $card->getBillingCountry());
             $billingDetails->addChild('zip', $card->getBillingPostcode());
             $billingDetails->addChild('phone', $card->getBillingPhone());
@@ -112,7 +111,6 @@ class AuthorizeRequest extends AbstractRequest
             $shippingDetails->addChild('street', $card->getShippingAddress1());
             $shippingDetails->addChild('street2', $card->getShippingAddress2());
             $shippingDetails->addChild('city', $card->getShippingCity());
-            $shippingDetails->addChild('state', $card->getShippingState());
             $shippingDetails->addChild('country', $card->getShippingCountry());
             $shippingDetails->addChild('zip', $card->getShippingPostcode());
             $shippingDetails->addChild('phone', $card->getShippingPhone());


### PR DESCRIPTION
Netbanx gives a parse error if the state value is blank or not US
